### PR TITLE
[nkm] feat: character customize

### DIFF
--- a/Assets/02. Scripts/Common/FusionInputProvider.cs
+++ b/Assets/02. Scripts/Common/FusionInputProvider.cs
@@ -12,17 +12,36 @@ public class FusionInputProvider : MonoBehaviour, INetworkRunnerCallbacks
     private Dictionary<PlayerRef, NetworkObject> _spawnedCharacters = new Dictionary<PlayerRef, NetworkObject>();
     private NetworkRunner _runner;
 
+    private string _nickname = "Player";
+    private Dictionary<EStatType, float> _statInputs = new();
+    private Dictionary<string, int> _customizeSelections = new();
+
     private void Awake()
     {
         _inputReader = FindAnyObjectByType<InputReader>();
+
+        // 초기화
+        foreach (EStatType stat in Enum.GetValues(typeof(EStatType)))
+        {
+            if (stat != EStatType.MaxHealth)
+                _statInputs[stat] = 10f;
+        }
+
+        string[] categories = new string[] {
+            "Axe", "Bag", "Bottom", "Bracelet", "Earring", "Eye", "Eyebrow", "Eyewear",
+            "Glove", "Hair", "HairAcc", "HandAcc", "Headgear", "Lips", "Mask", "Mustache",
+            "Shield", "Shoes", "Spear", "Sword", "Top", "Watch"
+        };
+
+        foreach (var category in categories)
+            _customizeSelections[category] = 1;
     }
+
     async void StartGame(GameMode mode)
     {
-        // Create the Fusion runner and let it know that we will be providing user input
         _runner = gameObject.AddComponent<NetworkRunner>();
         _runner.ProvideInput = true;
 
-        // Create the NetworkSceneInfo from the current scene
         var scene = SceneRef.FromIndex(SceneManager.GetActiveScene().buildIndex);
         var sceneInfo = new NetworkSceneInfo();
         if (scene.IsValid)
@@ -30,132 +49,167 @@ public class FusionInputProvider : MonoBehaviour, INetworkRunnerCallbacks
             sceneInfo.AddSceneRef(scene, LoadSceneMode.Additive);
         }
 
-        // Start or join (depends on gamemode) a session with a specific name
         await _runner.StartGame(new StartGameArgs()
         {
             GameMode = mode,
-            SessionName = "TestRoom",
+            SessionName = "FuckyouFusion",
             Scene = scene,
             SceneManager = gameObject.AddComponent<NetworkSceneManagerDefault>()
         });
     }
+
     private void OnGUI()
     {
+        GUILayout.BeginArea(new Rect(10, 10, 300, Screen.height));
+        GUILayout.Label("Nickname:");
+        _nickname = GUILayout.TextField(_nickname);
+
+        GUILayout.Space(10);
+        GUILayout.Label("Stats:");
+        foreach (EStatType stat in Enum.GetValues(typeof(EStatType)))
+        {
+            if (stat == EStatType.MaxHealth) continue;
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(stat.ToString(), GUILayout.Width(140));
+            string input = GUILayout.TextField(_statInputs[stat].ToString("F2"), GUILayout.Width(60));
+            input = input.Replace(',', '.');
+            if (float.TryParse(input, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out float val))
+                _statInputs[stat] = val;
+            GUILayout.EndHorizontal();
+        }
+
+
+        GUILayout.Space(10);
+        GUILayout.Label("Customization:");
+        Dictionary<string, int> maxCounts = new()
+        {
+            ["Axe"] = 3,
+            ["Bag"] = 18,
+            ["Bottom"] = 55,
+            ["Bracelet"] = 5,
+            ["Earring"] = 20,
+            ["Eye"] = 12,
+            ["Eyebrow"] = 23,
+            ["Eyewear"] = 18,
+            ["Glove"] = 22,
+            ["Hair"] = 28,
+            ["HairAcc"] = 3,
+            ["HandAcc"] = 10,
+            ["Headgear"] = 63,
+            ["Lips"] = 11,
+            ["Mask"] = 5,
+            ["Mustache"] = 29,
+            ["Shield"] = 4,
+            ["Shoes"] = 52,
+            ["Spear"] = 3,
+            ["Sword"] = 3,
+            ["Top"] = 71,
+            ["Watch"] = 5
+        };
+
+        foreach (var kvp in maxCounts)
+        {
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(kvp.Key, GUILayout.Width(100));
+            string input = GUILayout.TextField(_customizeSelections[kvp.Key].ToString(), GUILayout.Width(50));
+            if (int.TryParse(input, out int val))
+                _customizeSelections[kvp.Key] = Mathf.Clamp(val, 0, kvp.Value); // 0 허용
+            GUILayout.EndHorizontal();
+        }
+
+        
+
         if (_runner == null)
         {
-            if (GUI.Button(new Rect(0, 0, 200, 40), "Host"))
-            {
-                StartGame(GameMode.Host);
-            }
-            if (GUI.Button(new Rect(0, 40, 200, 40), "Join"))
-            {
-                StartGame(GameMode.Client);
-            }
+            GUILayout.Space(20);
+            if (GUILayout.Button("Host", GUILayout.Height(30))) StartGame(GameMode.Host);
+            if (GUILayout.Button("Join", GUILayout.Height(30))) StartGame(GameMode.Client);
         }
+        GUILayout.EndArea();
     }
+
     public void OnInput(NetworkRunner runner, NetworkInput input)
     {
         if (_inputReader == null) return;
 
         var move = _inputReader.MoveInput;
-        var isAttacking = _inputReader.ConsumeAttackInput();
-        var isRunning = _inputReader.IsRunning;
-        var isJumping = _inputReader.ConsumeJumpInput();
-        var isInteracting = _inputReader.ConsumeInteractionInput();
         var data = new NetworkInputData
         {
             direction = new Vector3(move.x, 0, move.y),
-            isAttacking = isAttacking,
-            isRunning = isRunning,
-            isJumping = isJumping,
-            isInteracting = isInteracting
+            isAttacking = _inputReader.ConsumeAttackInput(),
+            isRunning = _inputReader.IsRunning,
+            isJumping = _inputReader.ConsumeJumpInput(),
+            isInteracting = _inputReader.ConsumeInteractionInput()
         };
-
         input.Set(data);
-    }
-
-    public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player)
-    {
-    }
-
-    public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player)
-    {
     }
 
     public void OnPlayerJoined(NetworkRunner runner, PlayerRef player)
     {
         if (runner.IsServer)
         {
-            // Create a unique position for the player
-            Vector3 spawnPosition = new Vector3((player.RawEncoded % runner.Config.Simulation.PlayerCount) * 3, 1, 0);
-            NetworkObject networkPlayerObject = runner.Spawn(_playerPrefab, spawnPosition, Quaternion.identity, player);
-            // Keep track of the player avatars for easy access
-            _spawnedCharacters.Add(player, networkPlayerObject);
+            var baseStats = new Dictionary<EStatType, float>(_statInputs);
+
+            string GetName(string part) => _customizeSelections[part] > 0 ? part + "_" + _customizeSelections[part] : "";
+
+            var spawnData = new PlayerSpawnData(
+                CharacterClassType.Farmer, // 직업은 임시로 Farmer
+                GetName("Axe"), GetName("Bag"), GetName("Bottom"), GetName("Bracelet"), GetName("Earring"),
+                GetName("Eye"), GetName("Eyebrow"), GetName("Eyewear"), GetName("Glove"), GetName("Hair"),
+                GetName("HairAcc"), GetName("HandAcc"), GetName("Headgear"), GetName("Lips"), GetName("Mask"),
+                GetName("Mustache"), GetName("Shield"), GetName("Shoes"), GetName("Spear"), GetName("Sword"),
+                GetName("Top"), GetName("Watch"), baseStats, _nickname);
+
+            Vector3 spawnPos = new((player.RawEncoded % runner.Config.Simulation.PlayerCount) * 3, 1, 0);
+            runner.Spawn(_playerPrefab, spawnPos, Quaternion.identity, player,
+                onBeforeSpawned: (runner, obj) =>
+                {
+                    var handler = obj.GetComponent<PlayerClassHandler>();
+                    handler.SetCharacterInfo(
+                        spawnData.classType, spawnData.Nickname,
+                        spawnData.axe, spawnData.bag, spawnData.bottom, spawnData.bracelet, spawnData.earring,
+                        spawnData.eye, spawnData.eyebrow, spawnData.eyewear, spawnData.glove,
+                        spawnData.hair, spawnData.hairAcc, spawnData.handAcc, spawnData.headgear,
+                        spawnData.lips, spawnData.mask, spawnData.mustache, spawnData.shield,
+                        spawnData.shoes, spawnData.spear, spawnData.sword, spawnData.top, spawnData.watch);
+
+                    var stat = obj.GetComponent<PlayerStat>();
+                    stat.ApplyBaseStats(spawnData.baseStats);
+                });
         }
     }
 
     public void OnPlayerLeft(NetworkRunner runner, PlayerRef player)
     {
-        if (_spawnedCharacters.TryGetValue(player, out NetworkObject networkObject))
+        if (_spawnedCharacters.TryGetValue(player, out var networkObject))
         {
             runner.Despawn(networkObject);
             _spawnedCharacters.Remove(player);
         }
     }
 
-    public void OnShutdown(NetworkRunner runner, ShutdownReason shutdownReason)
+    public void OnShutdown(NetworkRunner runner, ShutdownReason shutdownReason) { }
+    public void OnDisconnectedFromServer(NetworkRunner runner, NetDisconnectReason reason) { }
+    public void OnConnectRequest(NetworkRunner runner, NetworkRunnerCallbackArgs.ConnectRequest request, byte[] token) { }
+    public void OnConnectFailed(NetworkRunner runner, NetAddress remoteAddress, NetConnectFailedReason reason) { }
+    public void OnUserSimulationMessage(NetworkRunner runner, SimulationMessagePtr message) { }
+    public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ReliableKey key, ArraySegment<byte> data) { }
+    public void OnReliableDataProgress(NetworkRunner runner, PlayerRef player, ReliableKey key, float progress) { }
+    public void OnInputMissing(NetworkRunner runner, PlayerRef player, NetworkInput input) { }
+    public void OnConnectedToServer(NetworkRunner runner) { }
+    public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList) { }
+    public void OnCustomAuthenticationResponse(NetworkRunner runner, Dictionary<string, object> data) { }
+    public void OnHostMigration(NetworkRunner runner, HostMigrationToken hostMigrationToken) { }
+    public void OnSceneLoadDone(NetworkRunner runner) { }
+    public void OnSceneLoadStart(NetworkRunner runner) { }
+
+    public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player)
     {
+        throw new NotImplementedException();
     }
 
-    public void OnDisconnectedFromServer(NetworkRunner runner, NetDisconnectReason reason)
+    public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player)
     {
-    }
-
-    public void OnConnectRequest(NetworkRunner runner, NetworkRunnerCallbackArgs.ConnectRequest request, byte[] token)
-    {
-    }
-
-    public void OnConnectFailed(NetworkRunner runner, NetAddress remoteAddress, NetConnectFailedReason reason)
-    {
-    }
-
-    public void OnUserSimulationMessage(NetworkRunner runner, SimulationMessagePtr message)
-    {
-    }
-
-    public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ReliableKey key, ArraySegment<byte> data)
-    {
-    }
-
-    public void OnReliableDataProgress(NetworkRunner runner, PlayerRef player, ReliableKey key, float progress)
-    {
-    }
-
-    public void OnInputMissing(NetworkRunner runner, PlayerRef player, NetworkInput input)
-    {
-    }
-
-    public void OnConnectedToServer(NetworkRunner runner)
-    {
-    }
-
-    public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList)
-    {
-    }
-
-    public void OnCustomAuthenticationResponse(NetworkRunner runner, Dictionary<string, object> data)
-    {
-    }
-
-    public void OnHostMigration(NetworkRunner runner, HostMigrationToken hostMigrationToken)
-    {
-    }
-
-    public void OnSceneLoadDone(NetworkRunner runner)
-    {
-    }
-
-    public void OnSceneLoadStart(NetworkRunner runner)
-    {
+        throw new NotImplementedException();
     }
 }

--- a/Assets/02. Scripts/Player/PlayerClassHandler.cs
+++ b/Assets/02. Scripts/Player/PlayerClassHandler.cs
@@ -1,6 +1,157 @@
-﻿using UnityEngine;
+﻿using Fusion;
+using UnityEngine;
+using System.Collections.Generic;
 
-// 직업 선택 및 특성 부여
-public class PlayerClassHandler:MonoBehaviour
+public enum CharacterClassType
 {
+    Warrior, Mage, Farmer, Chef
+}
+
+public class PlayerClassHandler : NetworkBehaviour
+{
+    [SerializeField] private CharacterClassType _classType;
+    [SerializeField] private string _nickname;
+
+    [Header("Customization Options")]
+    [SerializeField] private string _axe;
+    [SerializeField] private string _bag;
+    [SerializeField] private string _bottom;
+    [SerializeField] private string _bracelet;
+    [SerializeField] private string _earring;
+    [SerializeField] private string _eye;
+    [SerializeField] private string _eyebrow;
+    [SerializeField] private string _eyewear;
+    [SerializeField] private string _glove;
+    [SerializeField] private string _hair;
+    [SerializeField] private string _hairAcc;
+    [SerializeField] private string _handAcc;
+    [SerializeField] private string _headgear;
+    [SerializeField] private string _lips;
+    [SerializeField] private string _mask;
+    [SerializeField] private string _mustache;
+    [SerializeField] private string _shield;
+    [SerializeField] private string _shoes;
+    [SerializeField] private string _spear;
+    [SerializeField] private string _sword;
+    [SerializeField] private string _top;
+    [SerializeField] private string _watch;
+
+    public override void Spawned()
+    {
+        if (!Object.HasStateAuthority && !Object.HasInputAuthority)
+            return;
+
+        ApplyInitialStatsByClass();
+        ApplyCustomization();
+    }
+
+    private void Awake()
+    {
+        ApplyInitialStatsByClass();
+        ApplyCustomization();
+    }
+
+    private void ApplyInitialStatsByClass()
+    {
+        var stat = GetComponent<PlayerStat>();
+        if (stat == null) return;
+
+        switch (_classType)
+        {
+            case CharacterClassType.Warrior:
+                stat.ApplyModifier(EStatType.Armor, new StatModifier(StatModifierType.Add, 10, this));
+                stat.ApplyModifier(EStatType.Damage, new StatModifier(StatModifierType.Add, 5, this));
+                break;
+            case CharacterClassType.Mage:
+                stat.ApplyModifier(EStatType.Damage, new StatModifier(StatModifierType.Add, 15, this));
+                stat.ApplyModifier(EStatType.Armor, new StatModifier(StatModifierType.Add, -5, this));
+                break;
+            case CharacterClassType.Farmer:
+                stat.ApplyModifier(EStatType.ConsumptionRate, new StatModifier(StatModifierType.Multiply, 0.8f, this));
+                stat.ApplyModifier(EStatType.SprintingMultiplier, new StatModifier(StatModifierType.Add, 0.2f, this));
+                break;
+            case CharacterClassType.Chef:
+                stat.ApplyModifier(EStatType.AttackSpeed, new StatModifier(StatModifierType.Multiply, 1.3f, this));
+                stat.ApplyModifier(EStatType.Armor, new StatModifier(StatModifierType.Add, -3, this));
+                break;
+        }
+    }
+
+    private void ApplyCustomization()
+    {
+        Transform partRoot = transform.Find("Characters/Parts");
+        if (partRoot == null)
+        {
+            Debug.LogWarning("Character parts root not found");
+            return;
+        }
+
+        ActivatePart(partRoot, "Axe", _axe);
+        ActivatePart(partRoot, "Bag", _bag);
+        ActivatePart(partRoot, "Bottom", _bottom);
+        ActivatePart(partRoot, "Bracelet", _bracelet);
+        ActivatePart(partRoot, "Earring", _earring);
+        ActivatePart(partRoot, "Eye", _eye);
+        ActivatePart(partRoot, "Eyebrow", _eyebrow);
+        ActivatePart(partRoot, "Eyewear", _eyewear);
+        ActivatePart(partRoot, "Glove", _glove);
+        ActivatePart(partRoot, "Hair", _hair);
+        ActivatePart(partRoot, "HairAcc", _hairAcc);
+        ActivatePart(partRoot, "HandAcc", _handAcc);
+        ActivatePart(partRoot, "Headgear", _headgear);
+        ActivatePart(partRoot, "lips", _lips);
+        ActivatePart(partRoot, "Mask", _mask);
+        ActivatePart(partRoot, "Mustache", _mustache);
+        ActivatePart(partRoot, "Shield", _shield);
+        ActivatePart(partRoot, "Shoes", _shoes);
+        ActivatePart(partRoot, "Spear", _spear);
+        ActivatePart(partRoot, "Sword", _sword);
+        ActivatePart(partRoot, "Top", _top);
+        ActivatePart(partRoot, "Watch", _watch);
+    }
+
+    private void ActivatePart(Transform root, string category, string selectedName)
+    {
+        Transform categoryTransform = root.Find(category);
+        if (categoryTransform == null) return;
+
+        foreach (Transform child in categoryTransform)
+        {
+            child.gameObject.SetActive(child.name == selectedName);
+        }
+    }
+
+    public void SetCharacterInfo(
+        CharacterClassType classType, string nickname,
+        string axe, string bag, string bottom, string bracelet, string earring,
+        string eye, string eyebrow, string eyewear, string glove,
+        string hair, string hairAcc, string handAcc, string headgear,
+        string lips, string mask, string mustache, string shield,
+        string shoes, string spear, string sword, string top, string watch)
+    {
+        _classType = classType;
+        _nickname = nickname;
+        _axe = axe;
+        _bag = bag;
+        _bottom = bottom;
+        _bracelet = bracelet;
+        _earring = earring;
+        _eye = eye;
+        _eyebrow = eyebrow;
+        _eyewear = eyewear;
+        _glove = glove;
+        _hair = hair;
+        _hairAcc = hairAcc;
+        _handAcc = handAcc;
+        _headgear = headgear;
+        _lips = lips;
+        _mask = mask;
+        _mustache = mustache;
+        _shield = shield;
+        _shoes = shoes;
+        _spear = spear;
+        _sword = sword;
+        _top = top;
+        _watch = watch;
+    }
 }

--- a/Assets/02. Scripts/Player/PlayerSpawnData.cs
+++ b/Assets/02. Scripts/Player/PlayerSpawnData.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+
+[Serializable]
+public struct PlayerSpawnData
+{
+    public CharacterClassType classType;
+
+    // Customization
+    public string axe, bag, bottom, bracelet, earring;
+    public string eye, eyebrow, eyewear, glove;
+    public string hair, hairAcc, handAcc, headgear;
+    public string lips, mask, mustache, shield;
+    public string shoes, spear, sword, top, watch;
+
+    // Stats
+    public Dictionary<EStatType, float> baseStats;
+
+    public string Nickname;
+
+    public PlayerSpawnData(
+        CharacterClassType classType,
+        string axe, string bag, string bottom, string bracelet, string earring,
+        string eye, string eyebrow, string eyewear, string glove,
+        string hair, string hairAcc, string handAcc, string headgear,
+        string lips, string mask, string mustache, string shield,
+        string shoes, string spear, string sword, string top, string watch,
+        Dictionary<EStatType, float> baseStats, string nickname="박진혁")
+    {
+        this.classType = classType;
+        this.axe = axe;
+        this.bag = bag;
+        this.bottom = bottom;
+        this.bracelet = bracelet;
+        this.earring = earring;
+        this.eye = eye;
+        this.eyebrow = eyebrow;
+        this.eyewear = eyewear;
+        this.glove = glove;
+        this.hair = hair;
+        this.hairAcc = hairAcc;
+        this.handAcc = handAcc;
+        this.headgear = headgear;
+        this.lips = lips;
+        this.mask = mask;
+        this.mustache = mustache;
+        this.shield = shield;
+        this.shoes = shoes;
+        this.spear = spear;
+        this.sword = sword;
+        this.top = top;
+        this.watch = watch;
+        this.baseStats = baseStats;
+        Nickname = nickname;
+    }
+}

--- a/Assets/02. Scripts/Player/PlayerSpawnData.cs.meta
+++ b/Assets/02. Scripts/Player/PlayerSpawnData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 553a97e403ddbcb478d1d95d594bc686

--- a/Assets/02. Scripts/Player/Stat/PlayerStat.cs
+++ b/Assets/02. Scripts/Player/Stat/PlayerStat.cs
@@ -30,7 +30,16 @@ public class PlayerStat : MonoBehaviour
         OnDictionaryLoaded?.Invoke();
        // UIEventManager.Instance.OnDisplayStatChanged?.Invoke(new StatSnapshot());
     }
-
+    public void ApplyBaseStats(Dictionary<EStatType, float> baseStats)
+    {
+        foreach (var kvp in baseStats)
+        {
+            if (StatDictionary.TryGetValue(kvp.Key, out var stat))
+            {
+                stat.SetBaseStat(kvp.Value);
+            }
+        }
+    }
     public float GetStat(EStatType type)
     {
         if (StatDictionary.TryGetValue(type, out var stat))

--- a/Assets/02. Scripts/Player/Stat/Stat.cs
+++ b/Assets/02. Scripts/Player/Stat/Stat.cs
@@ -11,6 +11,10 @@ public class Stat
 
     private readonly List<StatModifier> _modifiers = new();
 
+    public void SetBaseStat(float value)
+    {
+        BaseStat = value;
+    }
     public Stat(float baseStat)
     {
         Level = 0;

--- a/Assets/02. Scripts/Player/StateMachine/PlayerStateBase.cs
+++ b/Assets/02. Scripts/Player/StateMachine/PlayerStateBase.cs
@@ -11,14 +11,6 @@
         _stat = controller.PlayerStat;
     }
 
-    public virtual void TryJump(NetworkInputData input)
-    {
-        if (input.isJumping && _controller.IsGrounded)
-        {
-            float jumpPower = _stat.GetStat(EStatType.JumpPower);
-            _controller.Jump(jumpPower);
-        }
-    }
     public virtual void Enter() { }
     public virtual void Exit() { }
     public virtual void Tick() { }

--- a/Assets/03. Prefabs/Character.prefab
+++ b/Assets/03. Prefabs/Character.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5436788278397013106}
+  - component: {fileID: -6953684102775807404}
   - component: {fileID: 2340262810978986176}
   - component: {fileID: 2733646110901959540}
   - component: {fileID: 8446609235003013225}
@@ -41,6 +42,42 @@ Transform:
   - {fileID: 3018360853148496028}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-6953684102775807404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4656477318081228857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf695a3b642efb7419827a39e1e6f3b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _classType: 0
+  _nickname: 
+  _axe: 
+  _bag: 
+  _bottom: 
+  _bracelet: 
+  _earring: 
+  _eye: 
+  _eyebrow: 
+  _eyewear: 
+  _glove: 
+  _hair: 
+  _hairAcc: 
+  _handAcc: 
+  _headgear: 
+  _lips: 
+  _mask: 
+  _mustache: 
+  _shield: 
+  _shoes: 
+  _spear: 
+  _sword: 
+  _top: 
+  _watch: 
 --- !u!114 &2340262810978986176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -70,6 +107,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: -6953684102775807404}
   - {fileID: 4301652561806454255}
   - {fileID: -1883298074901622383}
   - {fileID: 1441634403729200998}
@@ -653,6 +691,10 @@ PrefabInstance:
     - target: {fileID: 2485623284475983211, guid: 05725d6aa97304341bd5a8bd1bb7d615, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2491441171362140110, guid: 05725d6aa97304341bd5a8bd1bb7d615, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2495232626240723237, guid: 05725d6aa97304341bd5a8bd1bb7d615, type: 3}
       propertyPath: m_IsActive
@@ -1782,6 +1824,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7642105000674576461, guid: 05725d6aa97304341bd5a8bd1bb7d615, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7661175092410989940, guid: 05725d6aa97304341bd5a8bd1bb7d615, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1868,7 +1914,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8176953017467024260, guid: 05725d6aa97304341bd5a8bd1bb7d615, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8180647800624143630, guid: 05725d6aa97304341bd5a8bd1bb7d615, type: 3}
       propertyPath: m_IsActive


### PR DESCRIPTION
## 작업 내용
<!-- 어떤 기능을 구현했는지 설명해주세요 -->
- 게임 시작 전 `OnGUI()`를 통해 플레이어가 직접 캐릭터 커스터마이징 및 초기 스탯을 설정할 수 있는 UI 추가
- 닉네임 입력 기능 구현
- `EStatType` 기반 스탯 중 MaxHealth를 제외한 항목 설정 가능
- 커스터마이징 항목(Axe, Hair, Top 등)은 `PartName_Index` 형식으로 지정되며, 숫자 0 입력 시 해당 파츠 비활성화 처리
- 설정된 데이터는 `PlayerSpawnData`에 담겨 `onBeforeSpawned`를 통해 캐릭터 생성 시 반영되도록 구현

## 테스트 방법
<!-- 기능 확인을 위해 테스트해본 절차를 작성해주세요 -->
1. 게임 실행 후 OnGUI 화면에서 닉네임과 스탯, 커스터마이징 설정
2. "Host" 또는 "Join" 버튼 클릭
3. 캐릭터가 설정한 닉네임, 외형, 스탯으로 정상 생성되는지 확인
4. 커스터마이징 항목을 0으로 설정하면 해당 파츠가 비활성화되는지 확인

## 리뷰 요청
<!-- 공동작업자와 특별히 논의하고 싶은 부분이 있다면 작성해주세요 -->
- 커스터마이징 UI는 임시로 `OnGUI()` 기반으로 작성되었으며, 향후 UGUI 또는 정식 UI 시스템으로 교체 예정
- 현재 직업(classType)은 Farmer로 고정되어 있음 → 추후 직업 선택 기능 연동 필요
