### PR TITLE
[pjh] feat: DropZone 캔버스 추가

### DIFF
--- a/Assets/01. Scenes/InventoryTestScene.unity
+++ b/Assets/01. Scenes/InventoryTestScene.unity
@@ -1813,6 +1813,94 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1328723032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1328723033}
+  - component: {fileID: 1328723036}
+  - component: {fileID: 1328723035}
+  - component: {fileID: 1328723034}
+  m_Layer: 5
+  m_Name: DropZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1328723033
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1328723032}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2016855101}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1328723034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1328723032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1328723035
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1328723032}
+  m_CullTransparentMesh: 1
+--- !u!114 &1328723036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1328723032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 69c4b7302647677448d8acbe4dcc5955, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1486637187
 GameObject:
   m_ObjectHideFlags: 0
@@ -2306,6 +2394,108 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &2016855097
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2016855101}
+  - component: {fileID: 2016855100}
+  - component: {fileID: 2016855099}
+  - component: {fileID: 2016855098}
+  m_Layer: 5
+  m_Name: DropZoneCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2016855098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2016855097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &2016855099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2016855097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &2016855100
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2016855097}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: -10
+  m_TargetDisplay: 0
+--- !u!224 &2016855101
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2016855097}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1328723033}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &2083650063
 GameObject:
   m_ObjectHideFlags: 0
@@ -2454,6 +2644,7 @@ SceneRoots:
   - {fileID: 598192406}
   - {fileID: 1702869493}
   - {fileID: 1779111219}
+  - {fileID: 2016855101}
   - {fileID: 985775798}
   - {fileID: 1123302612}
   - {fileID: 977531091}

--- a/Assets/02. Scripts/Inventory/04.UI/UI_DropZone.cs
+++ b/Assets/02. Scripts/Inventory/04.UI/UI_DropZone.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class UI_DropZone : MonoBehaviour, IPointerDownHandler
+{
+	public void OnPointerDown(PointerEventData eventData)
+	{
+		if (eventData.button == PointerEventData.InputButton.Left)
+		{
+			if (!HandEntity.Instance.IsHandEmpty)
+			{
+				ItemStack itemInHand = HandEntity.Instance.ItemStack;
+				ItemManager.Instance.RPC_CreateItemObject(
+					itemInHand.ID,
+					itemInHand.Quantity, 
+					HandEntity.Instance.transform.position, 
+					HandEntity.Instance.transform.rotation);
+				HandEntity.Instance.DropItem();
+			}
+		}
+	}
+}

--- a/Assets/02. Scripts/Inventory/04.UI/UI_DropZone.cs.meta
+++ b/Assets/02. Scripts/Inventory/04.UI/UI_DropZone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69c4b7302647677448d8acbe4dcc5955

--- a/Assets/02. Scripts/Pointer/HandEntity.cs
+++ b/Assets/02. Scripts/Pointer/HandEntity.cs
@@ -13,4 +13,10 @@ public class HandEntity : BehaviourSingleton<HandEntity>
         ItemStack = itemStack;
         OnItemPickedUp?.Invoke();
     }
+    
+    public void DropItem()
+    {
+        ItemStack = null;
+        OnItemPickedUp?.Invoke();
+    }
 }

--- a/Assets/02. Scripts/Pointer/UI_Hand.cs
+++ b/Assets/02. Scripts/Pointer/UI_Hand.cs
@@ -21,10 +21,8 @@ public class UI_Hand : MonoBehaviour
 
 	private void Update()
 	{
-		// 캔버스 위에 존재하는 UI_Hand는 마우스 포지션을 따라다님
 		Vector2 mousePosition = Input.mousePosition;
 		transform.position = mousePosition;
-		
 	}
 	
 	public void UpdateHandUI()


### PR DESCRIPTION
Scene: InventoryTestScene

아이템 드랍을 감지하는 SortingLayer 후순위 캔버스와 패널을 설정하여 인벤토리 밖으로 아이템을 놓으면 필드 원점 (0,0,0)으로 아이템을 드랍합니다.

## 작업 내용
<!-- 어떤 기능을 구현했는지 설명해주세요 -->
- HandEntity에 아이템이 있을때 인벤토리 및 메인 캔버스에 띄워질 팝업 바깥을 클릭하면 아이템이 필드에 드랍됩니다.


## 테스트 방법
<!-- 기능 확인을 위해 테스트해본 절차를 작성해주세요 -->
- 인벤토리에서 아이템을 잡아서 바깥을 눌러보세요


## 관련 이슈 (선택)
<!-- 예: #42 -->
- 


## 리뷰 요청
<!-- 공동작업자와 특별히 논의하고 싶은 부분이 있다면 작성해주세요 -->
- DropZone이 항상 켜져있어도 괜찮을지 궁금합니다.
