### PR TITLE
[pjh] feat: DropZone On / Off 추가

### DIFF
--- a/Assets/02. Scripts/Inventory/04.UI/UI_DropZone.cs
+++ b/Assets/02. Scripts/Inventory/04.UI/UI_DropZone.cs
@@ -3,6 +3,17 @@ using UnityEngine.EventSystems;
 
 public class UI_DropZone : MonoBehaviour, IPointerDownHandler
 {
+	private void Start()
+	{
+		gameObject.SetActive(false);
+		HandEntity.Instance.OnItemPickedUp += ChangeDropZoneStatus;
+	}
+	
+	private void ChangeDropZoneStatus()
+	{
+		gameObject.SetActive(!HandEntity.Instance.IsHandEmpty);
+	}
+	
 	public void OnPointerDown(PointerEventData eventData)
 	{
 		if (eventData.button == PointerEventData.InputButton.Left)


### PR DESCRIPTION
Scene 작업 없음
HandEntity에 들고있는 ItemStack이 있을때만 DropZone 활성화 되도록 DropZone UI가 HandEntity의 Action을 구독합니다.

## 작업 내용
<!-- 어떤 기능을 구현했는지 설명해주세요 -->
- DropZone Panel이 HandEntity의 Action이 발동될 때 HandEntity의 IsHandEmpty Property를 참조하여 Activation이 변경됩니다.


## 테스트 방법
<!-- 기능 확인을 위해 테스트해본 절차를 작성해주세요 -->
- 아이템을 잡았을 때 DropZoneCanvas의 DropZone Panel의 활성화 여부를 확인하면 됩니다.


## 관련 이슈 (선택)
<!-- 예: #42 -->
- 


## 리뷰 요청
<!-- 공동작업자와 특별히 논의하고 싶은 부분이 있다면 작성해주세요 -->
-
