### PR TITLE
[nkm] feat: 부활 시스템 및 캐릭터 ID 관리 개선

### DIFF
--- a/Assets/02.Scripts/Common/PlayerInfoManager.cs
+++ b/Assets/02.Scripts/Common/PlayerInfoManager.cs
@@ -56,6 +56,8 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
 
     [Networked, Capacity(8)]
     public NetworkArray<PlayerInfo> Players => default;
+    [Networked, Capacity(20)]
+    public NetworkArray<string> CharacterIds => default;
     private readonly Dictionary<PlayerRef, string> _pendingNicknames = new();
     private readonly Queue<(PlayerRef playerRef, string nickname, NetworkId netId)> _registerQueue = new();
     private bool _isProcessingRegister;
@@ -64,16 +66,82 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
     private bool _networkReady;
     private bool _sceneReady;
 
-    public void RegisterLocal(Player player)
+    public void RegisterLocal(Player player, string id)
     {
         if (player == null) return;
-        _playerControllers[player.Object.InputAuthority] = player;
+
+        SyncPlayerControllers();
+
+        Rpc_RegisterCharacterId(id);
+    }
+
+    private void SyncPlayerControllers()
+    {
+        FindObjectsByType<Player>(FindObjectsSortMode.None).ToList().ForEach(p =>
+        {
+            if (p == null || !p.Object.IsValid) return;
+            _playerControllers[p.Object.InputAuthority] = p;
+        });
+    }
+
+    // 캐릭터 id 등록 RPC
+    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
+    public void Rpc_RegisterCharacterId(string characterId, RpcInfo info = default)
+    {
+        if (Object == null || !Object.HasStateAuthority) return;
+        var playerRef = info.Source;
+        for (int i = 0; i < CharacterIds.Length; i++)
+        {
+            if (Players[i].Ref == playerRef)
+            {
+                CharacterIds.Set(i, characterId);
+                return;
+            }
+        }
+    }
+
+    // 캐릭터 id 해제 RPC
+    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
+    public void Rpc_UnregisterCharacterId(RpcInfo info = default)
+    {
+        if (Object == null || !Object.HasStateAuthority) return;
+        var playerRef = info.Source;
+        for (int i = 0; i < CharacterIds.Length; i++)
+        {
+            if (Players[i].Ref == playerRef)
+            {
+                CharacterIds.Set(i, string.Empty);
+                return;
+            }
+        }
+    }
+
+    public Player FindPlayerFromId(string id)
+    {
+        for (int i = 0; i < CharacterIds.Length; i++)
+        {
+            Debug.Log($"[FindPlayerFromId] Checking index {i}: {CharacterIds[i]} vs {id}");
+            if (CharacterIds[i] == id)
+            {
+                Debug.Log($"[FindPlayerFromId] Match found at index {i} for ID {id}");
+                var playerRef = Players[i].Ref;
+                if (_playerControllers.TryGetValue(playerRef, out var player) && player)
+                    return player;
+                Debug.Log($"[FindPlayerFromId] No cached player for {playerRef}, attempting to resolve.");
+                var obj = Runner.FindObject(Players[i].NetworkId);
+                if (obj && obj.TryGetComponent(out Player resolved))
+                    return _playerControllers[playerRef] = resolved;
+            }
+        }
+        return null;
     }
 
     public void UnregisterLocal(Player player)
     {
         if (player == null) return;
         _playerControllers.Remove(player.Object.InputAuthority);
+
+        Rpc_UnregisterCharacterId();
     }
 
     public Player TryResolvePlayer(PlayerRef pref)
@@ -189,19 +257,6 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
     }
 
 
-    // Players 준비 확인 (네트워크 컨테이너 특성에 맞게 구현)
-    private bool IsPlayersReady()
-    {
-        try
-        {
-            var len = Players.Length; // 여기에 접근해도 터지지 않으면 OK
-            return len > 0 || len == 0; // 접근 자체가 성공하면 준비된 것
-        }
-        catch
-        {
-            return false;
-        }
-    }
 
     // 실제 등록 로직: 기존 RegisterPlayer 본문을 옮김
     private void RegisterPlayerInternal(PlayerRef playerRef, string nickname, NetworkId networkId)

--- a/Assets/02.Scripts/Common/PlayerInfoManager.cs
+++ b/Assets/02.Scripts/Common/PlayerInfoManager.cs
@@ -12,9 +12,12 @@ public struct PlayerInfo : INetworkStruct
     public PlayerRef Ref;
     public NetworkString<_16> Nickname;
     public NetworkId NetworkId;
+    public NetworkString<_16> CharacterId;
+
 }
 public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
 {
+    public bool EnableDebugLogs = false;
     public static PlayerInfoManager Instance { get; private set; }
     private void Awake()
     {
@@ -72,7 +75,7 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
 
         SyncPlayerControllers();
 
-        Rpc_RegisterCharacterId(id);
+        Rpc_UpdateCharacterId(player.NetworkObject.InputAuthority, id);
     }
 
     private void SyncPlayerControllers()
@@ -84,24 +87,8 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
         });
     }
 
-    // 캐릭터 id 등록 RPC
-    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
-    public void Rpc_RegisterCharacterId(string characterId, RpcInfo info = default)
-    {
-        if (Object == null || !Object.HasStateAuthority) return;
-        var playerRef = info.Source;
-        for (int i = 0; i < CharacterIds.Length; i++)
-        {
-            if (Players[i].Ref == playerRef)
-            {
-                CharacterIds.Set(i, characterId);
-                return;
-            }
-        }
-    }
 
     // 캐릭터 id 해제 RPC
-    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
     public void Rpc_UnregisterCharacterId(RpcInfo info = default)
     {
         if (Object == null || !Object.HasStateAuthority) return;
@@ -116,32 +103,13 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
         }
     }
 
-    public Player FindPlayerFromId(string id)
-    {
-        for (int i = 0; i < CharacterIds.Length; i++)
-        {
-            Debug.Log($"[FindPlayerFromId] Checking index {i}: {CharacterIds[i]} vs {id}");
-            if (CharacterIds[i] == id)
-            {
-                Debug.Log($"[FindPlayerFromId] Match found at index {i} for ID {id}");
-                var playerRef = Players[i].Ref;
-                if (_playerControllers.TryGetValue(playerRef, out var player) && player)
-                    return player;
-                Debug.Log($"[FindPlayerFromId] No cached player for {playerRef}, attempting to resolve.");
-                var obj = Runner.FindObject(Players[i].NetworkId);
-                if (obj && obj.TryGetComponent(out Player resolved))
-                    return _playerControllers[playerRef] = resolved;
-            }
-        }
-        return null;
-    }
+    
 
     public void UnregisterLocal(Player player)
     {
         if (player == null) return;
         _playerControllers.Remove(player.Object.InputAuthority);
 
-        Rpc_UnregisterCharacterId();
     }
 
     public Player TryResolvePlayer(PlayerRef pref)
@@ -168,13 +136,31 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
 
         if (obj == null)
         {
-            Debug.LogWarning($"No object found with NetworkId: {networkId}");
+                Debug.LogWarning($"No object found with NetworkId: {networkId}");
             return null;
         }
         if (obj.TryGetComponent(out Player player))
         {
             return player;
         }
+        return null;
+    }
+
+    public Player GetPlayerFromCharacterId(string characterId)
+    {
+        for (int i = 0; i < Players.Length; i++)
+        {
+            if (EnableDebugLogs)
+                Debug.Log($"Checking player at index {i}: CharacterId = {Players[i].CharacterId}, NetworkId = {Players[i].NetworkId}, Nickname = {Players[i].Nickname}");
+            if (Players[i].CharacterId.ToString() == characterId)
+            {
+                if (EnableDebugLogs)
+                    Debug.Log($"Found player with CharacterId: {characterId} at index {i}, {Players[i].Nickname}");
+                return GetPlayerFromNetworkId(Players[i].NetworkId);
+            }
+        }
+        if (EnableDebugLogs)
+            Debug.Log("No player found with CharacterId: " + characterId);
         return null;
     }
     public void UnregisterPlayer(NetworkRunner runner, PlayerRef playerRef)
@@ -187,7 +173,8 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
         {
             if (Players[i].Ref == playerRef)
             {
-                Debug.Log($"Unregistering player: {playerRef} at index {i}");
+                if (EnableDebugLogs)
+                    Debug.Log($"Unregistering player: {playerRef} at index {i}");
                 Players.Set(i, default);
                 Rpc_InvokeUnregistered(playerRef, i);
                 break;
@@ -246,7 +233,7 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
         catch (OperationCanceledException) { /* 정상 취소 */ }
         catch (TimeoutException)
         {
-            Debug.LogWarning("[PIM] Queue processing timeout. Flags => " +
+           Debug.LogWarning("[PIM] Queue processing timeout. Flags => " +
                              $"sceneReady:{_sceneReady}, networkReady:{_networkReady}, isServer:{runner.IsServer}");
             // 실패 시: 큐를 유지하고 다음 OnSceneLoadDone에서 다시 시도하도록 그냥 반환
         }
@@ -284,6 +271,27 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
         }
     }
 
+    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
+    public void Rpc_UpdateCharacterId(PlayerRef playerRef, string characterId)
+    {
+        if (Object == null || !Object.HasStateAuthority) return;
+        for (int i = 0; i < Players.Length; i++)
+        {
+            if (Players[i].Ref == playerRef)
+            {
+                var prev = Players[i];
+                Players.Set(i, new PlayerInfo
+                {
+                    Ref = playerRef,
+                    Nickname = prev.Nickname,
+                    NetworkId = prev.NetworkId,
+                    CharacterId = characterId.Substring(0, 16)
+                });
+                return;
+            }
+        }
+    }
+
     // 기존 UpdateNickname은 NetworkId 보존해서 덮어쓰기 (이미 적용했다면 그대로 유지)
     public void UpdateNickname(PlayerRef playerRef, string nickname)
     {
@@ -298,7 +306,8 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
                 {
                     Ref = playerRef,
                     Nickname = nickname,
-                    NetworkId = prev.NetworkId // 보존 중요
+                    NetworkId = prev.NetworkId,
+                    CharacterId = prev.CharacterId
                 });
                 return;
             }
@@ -374,7 +383,8 @@ public class PlayerInfoManager : NetworkBehaviour, INetworkRunnerCallbacks
                 return;
             }
 
-            Debug.Log($"[OnPlayerLeft] {player} Despawn 시도.");
+            if (EnableDebugLogs)
+                Debug.Log($"[OnPlayerLeft] {player} Despawn 시도.");
             _playerControllers.Remove(player);
             runner.Despawn(playerController.Object);
         }
@@ -435,7 +445,11 @@ void INetworkRunnerCallbacks.OnHostMigration(NetworkRunner runner, HostMigration
 void INetworkRunnerCallbacks.OnSceneLoadDone(NetworkRunner runner)
     {
         if (SceneManager.GetActiveScene().buildIndex != 3)
+        {
+            Debug.Log($"PlayerInfoManager: Not in the main game scene, skipping player spawn. Current SceneIndex: {SceneManager.GetActiveScene().buildIndex}");
             return;
+        }
+        Debug.Log($"PlayerInfoManager: Scene load done, processing pending joins. Current SceneIndex: {SceneManager.GetActiveScene().buildIndex}");
         _sceneReady = true; 
         TryProcessPendingJoins(runner);
     }

--- a/Assets/02.Scripts/NPC/03.Manager/ReviveShopManager.cs
+++ b/Assets/02.Scripts/NPC/03.Manager/ReviveShopManager.cs
@@ -74,4 +74,46 @@ public class ReviveShopManager : NetworkBehaviourSingleton<ReviveShopManager>
     {
         return ReviveShopInventory.SlotList.Exists(slot => slot.IsEmpty);
     }
+
+    public void TryRevive()
+    {
+        if (ReviveShopInventory.SlotList[0].IsEmpty)
+        {
+            UI_Notification.Notify("부활시킬 플레이어가 없습니다.");
+            return;
+        }
+        var reviveItem = ReviveShopInventory.SlotList[0].ItemInstance;
+        string extraInfo = reviveItem.ExtraInfo;
+
+        if (string.IsNullOrEmpty(extraInfo))
+        {
+            Debug.LogError("부활 아이템에 플레이어 정보가 없습니다.");
+            return;
+        }
+        Debug.Log(extraInfo);
+        var foundedPlayer = PlayerInfoManager.Instance.GetPlayerFromCharacterId(extraInfo);
+
+        if(foundedPlayer == null)
+        {
+            UI_Notification.Notify("해당 플레이어를 찾을 수 없습니다.");
+            ReviveShopInventory.PopItemInSlot(0);
+            OnReviveSlotUpdated[0]?.Invoke();
+            return;
+        }
+
+        if (!foundedPlayer.IsDead)
+        {
+            UI_Notification.Notify("이미 부활한 플레이어입니다.");
+            ReviveShopInventory.PopItemInSlot(0);
+            OnReviveSlotUpdated[0]?.Invoke();
+            return;
+        }
+
+        Debug.Log($"[ReviveShopManager] Reviving player: {foundedPlayer.NetworkObject.InputAuthority}");
+        foundedPlayer.Rpc_RequestRevive();
+        ReviveShopInventory.PopItemInSlot(0);
+
+        OnReviveSlotUpdated[0]?.Invoke();
+
+    }
 }

--- a/Assets/02.Scripts/NPC/03.Manager/ReviveShopManager.cs
+++ b/Assets/02.Scripts/NPC/03.Manager/ReviveShopManager.cs
@@ -27,7 +27,7 @@ public class ReviveShopManager : NetworkBehaviourSingleton<ReviveShopManager>
 
             if (HandEntity.Instance.GetItem().ItemProfile.ItemDefinition.Type != EItemType.Extra)
             {
-                UI_Notification.Notify("시체 아이템만 넣을 수 있습니다.");
+                UI_Notification.Notify("플레이어의 시체만 부활시킬 수 있습니다.");
                 return;
             }
 
@@ -58,7 +58,7 @@ public class ReviveShopManager : NetworkBehaviourSingleton<ReviveShopManager>
             {
                 if (HandEntity.Instance.GetItem().ItemProfile.ItemDefinition.Type != EItemType.Extra)
                 {
-                    UI_Notification.Notify("시체 아이템만 넣을 수 있습니다.");
+                    UI_Notification.Notify("플레이어의 시체만 부활시킬 수 있습니다.");
                     return;
                 }
                 

--- a/Assets/02.Scripts/NPC/04.UI/UI_ReviveButton.cs
+++ b/Assets/02.Scripts/NPC/04.UI/UI_ReviveButton.cs
@@ -4,7 +4,7 @@ public class UI_ReviveButton : MonoBehaviour
 {
     public void OnClickReviveButton()
     {
-        Debug.Log("Click");
+        ReviveShopManager.Instance?.TryRevive();
     }
         
 }

--- a/Assets/02.Scripts/Player/Player.cs
+++ b/Assets/02.Scripts/Player/Player.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.CompilerServices;
 using Fusion;
 using Fusion.Addons.FSM;
 using Fusion.Addons.SimpleKCC;
 using RaycastPro.Detectors;
 using Unity.Cinemachine;
 using UnityEngine;
+using System.Collections;
 
 [RequireComponent(typeof(RangeDetector))]
 public class Player : CharacterBase, IAttackable
@@ -127,7 +129,7 @@ public class Player : CharacterBase, IAttackable
                 return cam != null && cam.GetComponent<FollowCamera>() != null;
             }, cancellationToken: token).Timeout(TimeSpan.FromSeconds(3)).SuppressCancellationThrow();
 
-            TryBindFollowCamera(); // 가드 포함
+            TryBindFollowCamera();
         }
 
         // 3) Trait/HUD 초기화
@@ -140,7 +142,7 @@ public class Player : CharacterBase, IAttackable
             }
             else
             {
-                // 기존 코루틴 대신 UniTask 대기(최대 5초)
+                // 최대 5초 대기
                 await UniTask.WaitUntil(
                     () => ExpHandler != null && TraitDataList != null,
                     cancellationToken: token
@@ -163,7 +165,7 @@ public class Player : CharacterBase, IAttackable
                 GetInitialItem();
             else
             {
-                Debug.LogError("Fuckyou");
+                Debug.LogError("말도 안돼");
             }
 
             HookLocalTraitSavesIfOwner();
@@ -173,7 +175,12 @@ public class Player : CharacterBase, IAttackable
         await UniTask.Yield(); // 한 프레임 쉬고
                                // PlayerInfoManager 준비까지 대기 (최대 5초)
         await UniTask.WaitUntil(() => PlayerInfoManager.Instance != null, cancellationToken: token);
-        PlayerInfoManager.Instance.RegisterLocal(this);
+
+        if (HasInputAuthority)
+        {
+            string characterId = CharacterInfoManager.Instance.CharacterInfo.Id;
+            PlayerInfoManager.Instance.RegisterLocal(this, characterId);
+        }
         _spawnInitDone = true;
     }
 
@@ -551,6 +558,13 @@ public class Player : CharacterBase, IAttackable
         _teleportPosition = pos;
     }
 
+    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
+    public void Rpc_RequestRevive()
+    {
+        Debug.Log("[Client] Requesting Revive");
+        Revive();
+    }
+
     public void Revive()
     {
         if (!HasStateAuthority)
@@ -559,9 +573,21 @@ public class Player : CharacterBase, IAttackable
             Debug.Log("State에 요청을 해서 부활을 시키세요.");
             return;
         }
+        if (!IsDead)
+        {
+            Debug.Log("Not Dead");
+            return;
+        }
         PlayerFSM.IsInReviveProcess = true;
         SimpleKCC.enabled = true;
 
+        StartCoroutine(DelayedRevive());
+    }
+
+    IEnumerator DelayedRevive()
+    {
+        yield return new WaitForFixedUpdate();
+        Debug.Log("[Host] Reviving player..");
         RPC_ClientRevive();
     }
 
@@ -569,6 +595,7 @@ public class Player : CharacterBase, IAttackable
          HostMode = RpcHostMode.SourceIsHostPlayer)]
     private void RPC_ClientRevive()
     {
+        Debug.Log("[Client] Revive started.");
         if (_teleportManager == null)
         {
             _teleportManager = FindAnyObjectByType<TeleportManager>();

--- a/Assets/02.Scripts/Player/StateMachine/States/PlayerDeadState.cs
+++ b/Assets/02.Scripts/Player/StateMachine/States/PlayerDeadState.cs
@@ -29,13 +29,14 @@ public class PlayerDeadState : APlayerStateBase
             var position = _fsm.transform.position;
             var rotation = Quaternion.identity;
             var ownerId = CharacterInfoManager.Instance.CharacterInfo.Id;
+            var shortenId = ownerId.Length > 16 ? ownerId.Substring(0, 16) : ownerId;
             ItemProxySpawner.Instance.RPC_CreateItemObject(
                 corpseItemId,
                 1,
                 0f,
                 position,
                 rotation,
-                ownerId);
+                shortenId);
 
             var players = PlayerInfoManager.PlayerControllers.Values;
             bool allDead = players.Where(p => p != null && p.PlayerFSM != null).All(p => p.PlayerFSM.IsDead);


### PR DESCRIPTION
## 작업 내용
- 메시지 문구 변경  
  - `"시체 아이템만 넣을 수 있습니다."` → `"플레이어의 시체만 부활시킬 수 있습니다."`

- **`PlayerInfoManager` 개선**  
  - `CharacterIds` 속성 추가  
  - `RegisterLocal`에서 캐릭터 ID 등록 로직 추가  `Rpc_UpdateCharacterId`
  - `UnregisterLocal`에서 캐릭터 ID 해제
  - `SyncPlayerControllers` 메서드 추가 (플레이어 컨트롤러 전체 업데이트)  
  - `GetPlayerFromCharacterId` 메서드 추가  
  - `UpdateNickname`에서 캐릭터 ID 보존 처리 수정  
  - `OnSceneLoadDone`에 씬 확인 디버그 추가  
  - 불필요한 `IsPlayersReady` 관련 코드 제거  
  - `EnableDebugLogs` 변수 추가  

- **`PlayerInfo` 구조체**  
  - `CharacterId` 필드 추가  

- **`ReviveShopManager` 개선**  
  - `TryRevive` 메서드 추가 → 부활할 플레이어 확인 및 부활 요청 처리  
  - 부활 불가능 시 UI 알림 출력 및 슬롯 아이템 제거  
  - 플레이어 정보가 없는 경우 오류 로그 출력  

- **`Player` 클래스**  
  - `Rpc_RequestRevive` 메서드 추가  
  - `Revive` 메서드에 상태 권한 체크 및 에러 로그 추가  
  - `DelayedRevive` 코루틴으로 안정적으로 Rpc 날림  

- **기타 수정**  
  - `OnClickReviveButton`에서 `Debug.Log("Click")` 제거, 대신 `ReviveShopManager.Instance?.TryRevive();` 호출  
  - `ownerId`가 16자 초과 시 앞 16자만 사용하도록 수정 (ID 일관성 유지)  

## 테스트 방법
1. 플레이어 사망 후 시체 아이템을 슬롯에 넣고 부활 버튼 클릭 → 선택된 플레이어가 정상적으로 부활되는지 확인  
2. 이미 부활한 플레이어나 대상이 없는 경우 → UI에 알림이 출력되고 슬롯 아이템이 제거되는지 확인  
3. 닉네임 변경 시 캐릭터 ID가 유지되는지 확인  
4. 씬 로딩 완료 시 `OnSceneLoadDone`에서 씬 확인 로직이 정상적으로 동작하는지 검증  
5. `ownerId`가 16자 이상인 경우 RPC 호출 시 16자로 줄여 적용되는지 확인  

## 리뷰 요청
- 캐릭터 ID 등록/해제 및 닉네임 보존 로직이 올바르게 설계되었는지 확인  
- 부활 로직(`TryRevive`, `Rpc_RequestRevive`, `DelayedRevive`)의 권한 체크와 에러 핸들링이 적절한지 검토  
- `ownerId` 길이 제한 방식이 네트워크 동기화 및 데이터 일관성 유지에 문제 없는지 검토  
